### PR TITLE
Fix stale WebSocket preventing reconnection to controller

### DIFF
--- a/custom_components/jellyfish_lighting/api.py
+++ b/custom_components/jellyfish_lighting/api.py
@@ -84,7 +84,51 @@ class JellyfishLightingApiClient:
 
     def _attempt_reconnect(self, *args) -> None:
         """Attempts to reconnect to the controller"""
-        asyncio.run_coroutine_threadsafe(self.async_connect(), self._hass.loop)
+        LOGGER.warning(
+            "JellyFish controller connection error, scheduling reconnect to %s",
+            self.address,
+        )
+        asyncio.run_coroutine_threadsafe(self._async_reconnect(), self._hass.loop)
+
+    async def _async_reconnect(self):
+        """Force-close stale connection and reconnect.
+
+        The JellyFish controller only accepts one WebSocket connection at a
+        time. If the previous connection's TCP socket is still ESTABLISHED at
+        the kernel level (stale), new connection attempts will time out
+        indefinitely. We must tear down the old connection first.
+        """
+        LOGGER.debug(
+            "Force-closing stale connection to JellyFish controller at %s",
+            self.address,
+        )
+        await self._hass.async_add_executor_job(self._force_close_connection)
+        # Give the controller time to release the old session
+        await asyncio.sleep(2)
+        try:
+            await self.async_connect()
+        except HomeAssistantError:
+            LOGGER.warning(
+                "Reconnect to JellyFish controller at %s failed, will retry on next poll",
+                self.address,
+            )
+
+    def _force_close_connection(self):
+        """Force-close the underlying WebSocket and TCP connection."""
+        try:
+            self._controller.disconnect(timeout=3)
+        except Exception:  # noqa: BLE001
+            pass
+        # Also close the raw socket directly in case disconnect() didn't
+        # fully tear down the TCP connection
+        try:
+            ws = self._controller._JellyFishController__ws
+            if hasattr(ws, "close"):
+                ws.close()
+            if hasattr(ws, "sock") and ws.sock:
+                ws.sock.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     def _recieve_push(self, data):
         """Updates state data when a push event is received from the controller"""
@@ -124,6 +168,11 @@ class JellyfishLightingApiClient:
             return
         try:
             async with self._connecting:
+                # Force-close any stale connection before reconnecting.
+                # The JellyFish controller only accepts one WebSocket at a
+                # time, so a leftover TCP connection will block new ones.
+                await self._hass.async_add_executor_job(self._force_close_connection)
+                await asyncio.sleep(1)
                 LOGGER.debug(
                     "Connecting to the JellyFish Lighting controller at %s",
                     self.address,


### PR DESCRIPTION
## Problem

The JellyFish controller only accepts one WebSocket connection at a time. When the WebSocket daemon thread dies (due to a timeout, network blip, or controller hiccup), the underlying TCP connection can remain in ESTABLISHED state at the kernel level even though the application layer is no longer using it.

This ghost TCP connection blocks all subsequent reconnection attempts because the controller refuses new connections while the old one appears active. The result is a permanent error loop where every 15-second poll logs:

```
Error fetching jellyfish_lighting data
Failed to retrieve JellyFish controller information from <address>
```

The integration never recovers without a full Home Assistant restart.

## Root Cause Analysis

I traced this by inspecting the running HA container:

1. **ping to the controller succeeds** - network is fine
2. **A fresh websocket.create_connection() from a separate process times out** - the controller is rejecting it
3. **/proc/net/tcp shows an ESTABLISHED connection to the controller on port 9000** - from the HA process
4. **The WebSocket daemon thread is dead** - no thread running run_forever()

The TCP connection is alive at the kernel level but dead at the application level. The controller thinks the session is still active and will not accept a new one. controller.connect() creates a new WebSocketApp without closing the old one, so the stale TCP socket is never torn down.

## Fix

- Added _force_close_connection() to tear down both the WebSocket object and raw TCP socket
- Updated async_connect() to call _force_close_connection() before creating a new connection
- Updated _attempt_reconnect() to use a new _async_reconnect() method that cleanly tears down the old connection, waits briefly for the controller to release the session, then reconnects
- Added warning-level logging for connection errors and reconnect attempts

## Testing

Verified on a live system:
- Confirmed the controller rejects concurrent WebSocket connections (second connection times out while first is ESTABLISHED)
- Confirmed that after closing the stale connection, new connections succeed immediately
- After HA restart (which clears the stale connection), the integration reconnects and works normally

## Related Issues

- #30 - same symptom (Failed to retrieve JellyFish controller information), closed as stale
- #20 - Jellyfish Controller continually going unavailable