### PR TITLE
Update `jellyfishlights-py` dep and bump version

### DIFF
--- a/custom_components/jellyfish_lighting/manifest.json
+++ b/custom_components/jellyfish_lighting/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "jellyfishlights-py==0.8.1"
   ],
-  "version": "1.2.0"
+  "version": "1.3.6"
 }

--- a/custom_components/jellyfish_lighting/manifest.json
+++ b/custom_components/jellyfish_lighting/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/bdunn44/hass-jellyfish-lighting/issues",
   "requirements": [
-    "jellyfishlights-py==0.8.0"
+    "jellyfishlights-py==0.8.1"
   ],
   "version": "1.2.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorlog
 homeassistant==2026.2.2
-jellyfishlights-py==0.8.0
+jellyfishlights-py==0.8.1


### PR DESCRIPTION
Fixes #36 

- Includes the `activatedBy` fix for latest `jellyfishlights-py`, so initialization completes successfully.
- also bump the version listed in `manifest.json`