### PR TITLE
Reconnect on clean socket close and stop entities flapping unavailable

### DIFF
--- a/custom_components/jellyfish_lighting/api.py
+++ b/custom_components/jellyfish_lighting/api.py
@@ -37,6 +37,7 @@ class JellyfishLightingApiClient:
         self._controller = JellyFishController(address)
         self._connecting = asyncio.Lock()
         self._reconnecting = False
+        self._closing = False
         self.zones: List[str] = []
         self.states: Dict[str, JellyFishLightingZoneData] = {}
         self.patterns: List[str] = []
@@ -44,7 +45,9 @@ class JellyfishLightingApiClient:
         self.hostname: str = None
         self.version: str = None
         self._controller.add_listener(
-            on_message=self._recieve_push, on_error=self._attempt_reconnect
+            on_message=self._recieve_push,
+            on_error=self._attempt_reconnect,
+            on_close=self._attempt_reconnect,
         )
 
     @property
@@ -60,6 +63,11 @@ class JellyfishLightingApiClient:
     def connected(self) -> bool:
         """Indicates whether the client is connected to the controller"""
         return self._controller.connected
+
+    @property
+    def reconnecting(self) -> bool:
+        """Indicates whether a reconnect attempt is currently in progress"""
+        return self._reconnecting
 
     def register_push_listener(self, entity: CoordinatorEntity) -> None:
         """Adds a listener that is called when push events are received from the controller"""
@@ -84,11 +92,19 @@ class JellyfishLightingApiClient:
         )
 
     def _attempt_reconnect(self, *args) -> None:
-        """Attempts to reconnect to the controller"""
-        if self._reconnecting:
+        """Schedules a reconnect after an unexpected disconnect.
+
+        Wired to both on_error and on_close. The JellyFish controller closes
+        idle WebSocket connections cleanly (on_close, no error), which is why
+        entities silently went unavailable with nothing logged - the previous
+        code only reconnected on_error. Skip when the disconnect is our own
+        doing: an intentional disconnect, or the force-close that happens
+        inside a connect / reconnect already in progress.
+        """
+        if self._closing or self._reconnecting or self.connecting or self.connected:
             return
-        LOGGER.warning(
-            "JellyFish controller connection error, scheduling reconnect to %s",
+        LOGGER.debug(
+            "JellyFish controller at %s disconnected; scheduling reconnect",
             self.address,
         )
         self._reconnecting = True
@@ -172,6 +188,7 @@ class JellyfishLightingApiClient:
 
     async def async_connect(self):
         """Establish connection to the controller"""
+        self._closing = False
         if self.connected or self.connecting:
             return
         try:
@@ -193,6 +210,7 @@ class JellyfishLightingApiClient:
 
     async def async_disconnect(self):
         """Disconnects from the controller"""
+        self._closing = True
         if not self.connected:
             return
         try:

--- a/custom_components/jellyfish_lighting/light.py
+++ b/custom_components/jellyfish_lighting/light.py
@@ -59,12 +59,18 @@ class JellyfishLightingLight(JellyfishLightingEntity, LightEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        try:
-            self.api.states[self.zone]
-        except KeyError:
+        """Return True if entity is available.
+
+        The controller closes idle WebSocket connections cleanly, and we
+        reconnect automatically. Treat the entity as available while a
+        (re)connect is in flight so a routine idle-close does not flap the
+        light (and anything templated on it) to unavailable and back. It still
+        reports unavailable when the controller is genuinely gone - i.e. once
+        we are neither connected nor actively trying.
+        """
+        if self.api.states.get(self.zone) is None:
             return False
-        return self.api.connected
+        return self.api.connected or self.api.connecting or self.api.reconnecting
 
     @property
     def effect_list(self) -> list[str]:


### PR DESCRIPTION
The JellyFish controller closes idle WebSocket connections cleanly, firing on_close rather than on_error. Reconnect was only wired to on_error, so a clean close left the connection down until the next coordinator poll happened to reconnect it - with nothing logged. Meanwhile the light's `available` property returns self.api.connected directly, so every idle-close flapped the light (and any template entities derived from it) to unavailable and back.

- Wire on_close to the reconnect handler as well as on_error, with guards (_closing / _reconnecting / connecting / connected) so our own intentional or in-progress socket teardown does not trigger a spurious reconnect.
- Add a `reconnecting` property and treat the entity as available while a (re)connect is in flight, so a routine idle-close no longer flaps the UI. It still reports unavailable once the controller is genuinely gone.